### PR TITLE
Add basic command completion

### DIFF
--- a/lua/automaton/init.lua
+++ b/lua/automaton/init.lua
@@ -440,7 +440,25 @@ function Automaton.setup(config)
         else
             error("Unknown action '" .. action .. "'")
         end
-    end, { nargs = "+" })
+    end, {
+        nargs = "+",
+        desc = 'Automaton',
+        -- The function parameters are: ArgLead, CmdLine, CursorPos
+        complete = function(_, _, _)
+            return {
+                "create",
+                "recents",
+                "workspaces",
+                "init",
+                "load",
+                "jobs",
+                "config",
+                "launch",
+                "tasks",
+                "open"
+            }
+        end
+    })
 end
 
 return Automaton


### PR DESCRIPTION
Thank you for this awesome plugin. This PR adds cmdline completion for basic sub-commands:

<img width="226" alt="Screenshot 2023-03-05 at 00 19 18" src="https://user-images.githubusercontent.com/41125715/222931151-74d3695b-2bf8-4155-ac8c-7d69548468e1.png">

In the future, you can improve this function and add argument parsing for sub-commands. For example, see [telescope@plugin/telescope.lua#L108-L143](https://github.com/nvim-telescope/telescope.nvim/blob/e7e90466de0571d39fe642cdfec1c577451b8be1/plugin/telescope.lua#L108-L143).