### PR TITLE
fix(Workspace): vim.ui.input expected table

### DIFF
--- a/lua/automaton/init.lua
+++ b/lua/automaton/init.lua
@@ -251,7 +251,7 @@ function Automaton.recent_workspaces()
 end
 
 function Automaton.create_workspace()
-    vim.ui.input("Workspace name", function(wsname)
+    vim.ui.input({prompt = "Workspace name "}, function(wsname)
         if wsname and string.len(wsname) then
             require("automaton.picker").select_folder(function(p)
                 Automaton.init_workspace(Path:new(p, wsname))


### PR DESCRIPTION
I got follow error after using `:Automaton create` cmd:

```
Error executing Lua callback: vim/shared.lua:0: Expected table, got string
stack traceback:
        [C]: in function 'assert'
        vim/shared.lua: in function 'tbl_isempty'
        /opt/local/share/nvim/runtime/lua/vim/ui.lua:92: in function 'input'
        ...al/share/nvim/lazy/automaton.nvim/lua/automaton/init.lua:254: in function 'create_workspace'
        ...al/share/nvim/lazy/automaton.nvim/lua/automaton/init.lua:433: in function <...al/share/nvim/lazy/automaton.nvim/lua/automaton/init.lua:423>
```
