### PR TITLE
feat: add toggle command for terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,23 +104,24 @@ require("automaton").setup({
 ### Commands
 
 ```lua
-:Automaton create         -- Create a new workspace
-           recents        -- Shows recent workspaces
-           init           -- Initializes a workspace in "cwd"
-           load           -- Loads a workspace in "cwd"
-           workspaces     -- Manage loaded workspaces
-           jobs           -- Shows running tasks/launch (can be killed too)
-           config         -- Show/Edit workspace settings
-           tasks default  -- Exec default task
-           tasks          -- Select and exec task
-           launch default -- Exec default launch configuration
-           launch         -- Select and exec a launch configuration
-           debug default  -- Debug default launch configuration
-           debug          -- Select and debug a launch configuration
-           open launch    -- Open workspace's launch.json
-           open tasks     -- Open workspace's tasks.json
-           open variables -- Open workspace's variables.json
-           open config    -- Open workspace's config.json
+:Automaton create           -- Create a new workspace
+           recents          -- Shows recent workspaces
+           init             -- Initializes a workspace in "cwd"
+           load             -- Loads a workspace in "cwd"
+           workspaces       -- Manage loaded workspaces
+           jobs             -- Shows running tasks/launch (can be killed too)
+           config           -- Show/Edit workspace settings
+           tasks default    -- Exec default task
+           tasks            -- Select and exec task
+           launch default   -- Exec default launch configuration
+           launch           -- Select and exec a launch configuration
+           debug default    -- Debug default launch configuration
+           debug            -- Select and debug a launch configuration
+           open launch      -- Open workspace's launch.json
+           open tasks       -- Open workspace's tasks.json
+           open variables   -- Open workspace's variables.json
+           open config      -- Open workspace's config.json
+           toggle_terminal  -- Toggle's the terminal opened when executing a task
 ```
 
 ## Workspace
@@ -199,6 +200,8 @@ vim.keymap.set("n", "<leader>aol", "<CMD>Automaton open launch<CR>")
 vim.keymap.set("n", "<leader>aov", "<CMD>Automaton open variables<CR>")
 vim.keymap.set("n", "<leader>aot", "<CMD>Automaton open tasks<CR>")
 vim.keymap.set("n", "<leader>aoc", "<CMD>Automaton open config<CR>")
+
+vim.keymap.set("n", "<leader>ax", "<CMD>Automaton toggle_terminal<CR>")
 
 -- Visual Mode
 vim.keymap.set("v", "<F5>", "<CMD><C-U>Automaton launch default<CR>")

--- a/lua/automaton/init.lua
+++ b/lua/automaton/init.lua
@@ -464,6 +464,8 @@ function Automaton.setup(config)
             elseif arg == "config" then
                 ws:open_config()
             end
+        elseif action == "toggle_terminal" then
+            require("automaton.runner").toggle_terminal(Automaton.config)
         else
             error("Unknown action '" .. action .. "'")
         end
@@ -478,7 +480,8 @@ function Automaton.setup(config)
             local COMMANDS = { "create", "recents", "workspaces", "init", "load" }
 
             if ws then
-                COMMANDS = vim.list_extend(COMMANDS, { "jobs", "config", "debug", "launch", "tasks", "open" })
+                COMMANDS = vim.list_extend(COMMANDS, { "jobs", "config", "debug", 
+                    "launch", "tasks", "open", "toggle_terminal" })
             end
 
             if vim.tbl_isempty(args) then

--- a/lua/automaton/runner.lua
+++ b/lua/automaton/runner.lua
@@ -79,6 +79,34 @@ function Runner.close_terminal()
     end
 end
 
+
+function Runner.toggle_terminal(config)
+    local bufid = Runner.termbufid
+    local winid = Runner.termwinid
+    if bufid == nil or not vim.api.nvim_buf_is_valid(bufid) then
+        vim.notify("No automaton output available")
+        return
+    end
+
+    if winid ~= nil and vim.api.nvim_win_is_valid(winid) then
+        -- don't use close_terminal(), as that destructively closes,
+        -- i.e. we can't recall the previous instance
+        vim.api.nvim_win_close(winid, false)
+        Runner.termwinid = nil
+    else
+        -- reopen at previous position. should never be empty, but botright if it was
+        vim.api.nvim_command(vim.F.if_nil(config.terminal.position, "botright") .. " split")
+        local new_win = vim.api.nvim_get_current_win()
+        vim.api.nvim_win_set_buf(new_win, bufid)
+        Runner.termwinid = new_win
+        -- reopen in previous size, reset focus to the window
+        -- that had focus before reopening the terminal
+        vim.api.nvim_command("resize " .. tostring(vim.F.if_nil(config.terminal.size, 10)))
+        vim.api.nvim_command("wincmd p")
+    end
+        
+end
+
 function Runner.clear_quickfix(e)
     vim.fn.setqflist({}, " ", { title = vim.F.if_nil(e.name, "Output") })
 end


### PR DESCRIPTION
As suggested before in #13 , add a toggle command to (non destructively) close and reopen the terminal window. Since this is non destructive, it is different form the close_terminal command.

I chose a somewhat random key for the example, as my local shortcuts are very different from the suggestions. Feel free to use a different one